### PR TITLE
Fix user doc creation and search count persistence

### DIFF
--- a/client/context/AuthContext.tsx
+++ b/client/context/AuthContext.tsx
@@ -86,7 +86,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       loading,
       async signIn(email, password) {
         const _auth = getAuthInstance();
-        await signInWithEmailAndPassword(_auth, email, password);
+        const cred = await signInWithEmailAndPassword(_auth, email, password);
+        if (cred.user) {
+          try {
+            await ensureUserDoc(
+              cred.user.uid,
+              cred.user.email,
+              cred.user.displayName,
+            );
+          } catch (e) {
+            console.warn("ensureUserDoc on signIn failed: ", e);
+          }
+        }
       },
       async signUp(name, email, password) {
         const _auth = getAuthInstance();
@@ -102,7 +113,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       },
       async signInWithGoogle() {
         const _auth = getAuthInstance();
-        await signInWithPopup(_auth, getGoogleProvider());
+        const cred = await signInWithPopup(_auth, getGoogleProvider());
+        if (cred.user) {
+          try {
+            await ensureUserDoc(
+              cred.user.uid,
+              cred.user.email,
+              cred.user.displayName,
+            );
+          } catch (e) {
+            console.warn("ensureUserDoc on Google sign-in failed: ", e);
+          }
+        }
       },
       async signOut() {
         const _auth = getAuthInstance();


### PR DESCRIPTION
## Purpose

The user was experiencing two critical issues:
1. User documents were not being automatically created in Firestore when new users signed up
2. User search counts were being reset to 0 after page refresh, even when manually set to other values in the database

The goal was to ensure proper user document creation during authentication and fix the search count persistence logic.

## Code changes

**AuthContext.tsx:**
- Added `ensureUserDoc` calls after successful sign-in operations (email/password and Google sign-in)
- Captures user credentials and creates/updates user documents with proper error handling
- Ensures user documents exist immediately after authentication

**user.ts:**
- Removed the forced cap of 2 free searches that was overriding database values
- Simplified the normalization logic to only update `totalSearchesRemaining` when it's invalid (not finite or negative)
- Removed unnecessary `freeSearches` field updates that were causing data inconsistencies
- Fixed the condition logic to preserve existing valid search counts instead of constantly recalculating them

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb67991c83d2474592283b1ac1a52054/orbit-garden)

👀 [Preview Link](https://fb67991c83d2474592283b1ac1a52054-orbit-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb67991c83d2474592283b1ac1a52054</projectId>-->
<!--<branchName>orbit-garden</branchName>-->