### PR TITLE
Fix results layout: switch to responsive grid design

### DIFF
--- a/client/components/results/ResultsList.tsx
+++ b/client/components/results/ResultsList.tsx
@@ -150,7 +150,10 @@ function FieldColumn({ fields }: { fields: ResultField[] }) {
   return (
     <dl className="space-y-4">
       {fields.map((field) => (
-        <div key={field.key} className="grid grid-cols-1 sm:[grid-template-columns:180px_1fr] items-start gap-2 sm:gap-3">
+        <div
+          key={field.key}
+          className="grid grid-cols-1 sm:[grid-template-columns:180px_1fr] items-start gap-2 sm:gap-3"
+        >
           <dt className="text-sm font-extrabold tracking-wide text-brand-600 dark:text-brand-300">
             {field.label}
           </dt>

--- a/client/components/results/ResultsList.tsx
+++ b/client/components/results/ResultsList.tsx
@@ -56,7 +56,7 @@ export function ResultsList({ records }: { records: ResultRecord[] }) {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="grid gap-6 md:grid-cols-2">
       {records.map((record, index) => (
         <ResultCard
           key={record.id || index}
@@ -96,7 +96,7 @@ function ResultCard({
   const fieldCount = record.fields.length;
 
   return (
-    <article className="rounded-2xl border border-border bg-card/90 p-6 shadow-sm shadow-brand-500/10 ring-1 ring-brand-500/10 backdrop-blur">
+    <article className="rounded-2xl border border-border bg-card/90 p-6 shadow-sm shadow-brand-500/10 ring-1 ring-brand-500/10 backdrop-blur h-full">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-1">
           <h2 className="text-2xl font-extrabold tracking-tight text-foreground md:text-3xl">
@@ -150,11 +150,11 @@ function FieldColumn({ fields }: { fields: ResultField[] }) {
   return (
     <dl className="space-y-4">
       {fields.map((field) => (
-        <div key={field.key} className="grid grid-cols-3 items-start gap-3">
-          <dt className="col-span-1 text-sm font-extrabold tracking-wide text-brand-600 dark:text-brand-300">
+        <div key={field.key} className="grid grid-cols-1 sm:[grid-template-columns:180px_1fr] items-start gap-2 sm:gap-3">
+          <dt className="text-sm font-extrabold tracking-wide text-brand-600 dark:text-brand-300">
             {field.label}
           </dt>
-          <dd className="col-span-2 break-words text-base font-medium text-foreground">
+          <dd className="min-w-0 break-words text-base font-medium text-foreground">
             <ValueRenderer value={field.value} />
           </dd>
         </div>
@@ -246,10 +246,10 @@ function ObjectRenderer({ obj }: { obj: Record<string, ResultValue> }) {
     <dl className="space-y-3">
       {entries.map(([key, v]) => (
         <div key={key} className="grid grid-cols-3 items-start gap-3">
-          <dt className="col-span-1 text-sm font-extrabold tracking-wide text-brand-600 dark:text-brand-300">
+          <dt className="text-sm font-extrabold tracking-wide text-brand-600 dark:text-brand-300">
             {formatLabel(key)}
           </dt>
-          <dd className="col-span-2 break-words text-base font-medium text-foreground">
+          <dd className="min-w-0 break-words text-base font-medium text-foreground">
             <ValueRenderer value={v} />
           </dd>
         </div>


### PR DESCRIPTION
## Purpose

The results page was displaying data in a broken vertical column layout where text appeared stacked letter-by-letter, making results completely unreadable. The user requested a redesign to present data in a clear, user-friendly format with proper spacing, alignment, and structure similar to professional result pages like "Have I Been Pwned".

## Code changes

- **Layout restructure**: Changed main results container from vertical flex layout (`flex flex-col`) to responsive grid (`grid gap-6 md:grid-cols-2`) for better space utilization
- **Card improvements**: Added `h-full` class to result cards to ensure consistent height across grid items
- **Field layout optimization**: 
  - Replaced rigid 3-column grid with responsive layout using `grid-cols-1 sm:[grid-template-columns:180px_1fr]`
  - Improved spacing with responsive gaps (`gap-2 sm:gap-3`)
  - Added `min-w-0` to field values to prevent overflow issues
- **Responsive design**: Enhanced mobile and desktop viewing experience with proper breakpoints
- **Consistent styling**: Removed explicit column span classes and improved text wrapping behavior

The changes transform the cramped vertical display into a clean, readable grid layout that adapts to different screen sizes.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb67991c83d2474592283b1ac1a52054/pixel-den)

👀 [Preview Link](https://fb67991c83d2474592283b1ac1a52054-pixel-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb67991c83d2474592283b1ac1a52054</projectId>-->
<!--<branchName>pixel-den</branchName>-->